### PR TITLE
Change (cmd): Revert images to use `CMD` `/bin/sh` and `/bin/bash`

### DIFF
--- a/variants/alpine/3.10/Dockerfile
+++ b/variants/alpine/3.10/Dockerfile
@@ -6,4 +6,4 @@ RUN apk update \
     && apk add --no-cache ansible=2.8.19-r0 openssh-client \
     && rm -rf /var/cache/apk/*
 
-CMD ["ansible"]
+CMD ["/bin/sh"]

--- a/variants/alpine/3.11/Dockerfile
+++ b/variants/alpine/3.11/Dockerfile
@@ -6,4 +6,4 @@ RUN apk update \
     && apk add --no-cache ansible=2.9.18-r0 openssh-client \
     && rm -rf /var/cache/apk/*
 
-CMD ["ansible"]
+CMD ["/bin/sh"]

--- a/variants/alpine/3.12/Dockerfile
+++ b/variants/alpine/3.12/Dockerfile
@@ -6,4 +6,4 @@ RUN apk update \
     && apk add --no-cache ansible=2.9.18-r0 openssh-client \
     && rm -rf /var/cache/apk/*
 
-CMD ["ansible"]
+CMD ["/bin/sh"]

--- a/variants/alpine/3.13/Dockerfile
+++ b/variants/alpine/3.13/Dockerfile
@@ -6,4 +6,4 @@ RUN apk update \
     && apk add --no-cache ansible=2.10.7-r0 openssh-client \
     && rm -rf /var/cache/apk/*
 
-CMD ["ansible"]
+CMD ["/bin/sh"]

--- a/variants/alpine/3.14/Dockerfile
+++ b/variants/alpine/3.14/Dockerfile
@@ -6,4 +6,4 @@ RUN apk update \
     && apk add --no-cache ansible=2.10.7-r0 openssh-client \
     && rm -rf /var/cache/apk/*
 
-CMD ["ansible"]
+CMD ["/bin/sh"]

--- a/variants/alpine/3.15/Dockerfile
+++ b/variants/alpine/3.15/Dockerfile
@@ -6,4 +6,4 @@ RUN apk update \
     && apk add --no-cache ansible=4.8.0-r0 openssh-client \
     && rm -rf /var/cache/apk/*
 
-CMD ["ansible"]
+CMD ["/bin/sh"]

--- a/variants/alpine/3.16/Dockerfile
+++ b/variants/alpine/3.16/Dockerfile
@@ -6,4 +6,4 @@ RUN apk update \
     && apk add --no-cache ansible=5.8.0-r0 openssh-client \
     && rm -rf /var/cache/apk/*
 
-CMD ["ansible"]
+CMD ["/bin/sh"]

--- a/variants/alpine/3.17/Dockerfile
+++ b/variants/alpine/3.17/Dockerfile
@@ -6,4 +6,4 @@ RUN apk update \
     && apk add --no-cache ansible=6.6.0-r0 openssh-client \
     && rm -rf /var/cache/apk/*
 
-CMD ["ansible"]
+CMD ["/bin/sh"]

--- a/variants/alpine/3.8/Dockerfile
+++ b/variants/alpine/3.8/Dockerfile
@@ -6,4 +6,4 @@ RUN apk update \
     && apk add --no-cache ansible=2.6.20-r0 openssh-client \
     && rm -rf /var/cache/apk/*
 
-CMD ["ansible"]
+CMD ["/bin/sh"]

--- a/variants/alpine/3.9/Dockerfile
+++ b/variants/alpine/3.9/Dockerfile
@@ -6,4 +6,4 @@ RUN apk update \
     && apk add --no-cache ansible=2.7.17-r0 openssh-client \
     && rm -rf /var/cache/apk/*
 
-CMD ["ansible"]
+CMD ["/bin/sh"]

--- a/variants/alpine/edge/Dockerfile
+++ b/variants/alpine/edge/Dockerfile
@@ -6,4 +6,4 @@ RUN apk update \
     && apk add --no-cache ansible=7.1.0-r0 openssh-client \
     && rm -rf /var/cache/apk/*
 
-CMD ["ansible"]
+CMD ["/bin/sh"]

--- a/variants/ubuntu/16.04-ppa/Dockerfile
+++ b/variants/ubuntu/16.04-ppa/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update \
     && apt-get remove -y --autoremove software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
-CMD ["ansible"]
+CMD ["/bin/bash"]

--- a/variants/ubuntu/16.04/Dockerfile
+++ b/variants/ubuntu/16.04/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get update \
     && apt-get install -y ansible=2.1.1.0-1~ubuntu16.04.1 openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
-CMD ["ansible"]
+CMD ["/bin/bash"]

--- a/variants/ubuntu/18.04-ppa/Dockerfile
+++ b/variants/ubuntu/18.04-ppa/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update \
     && apt-get remove -y --autoremove software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
-CMD ["ansible"]
+CMD ["/bin/bash"]

--- a/variants/ubuntu/18.04/Dockerfile
+++ b/variants/ubuntu/18.04/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get update \
     && apt-get install -y ansible=2.5.1+dfsg-1ubuntu0.1 openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
-CMD ["ansible"]
+CMD ["/bin/bash"]

--- a/variants/ubuntu/20.04-ppa/Dockerfile
+++ b/variants/ubuntu/20.04-ppa/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update \
     && apt-get remove -y --autoremove software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
-CMD ["ansible"]
+CMD ["/bin/bash"]

--- a/variants/ubuntu/20.04/Dockerfile
+++ b/variants/ubuntu/20.04/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get update \
     && apt-get install -y ansible=2.9.6+dfsg-1 openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
-CMD ["ansible"]
+CMD ["/bin/bash"]

--- a/variants/ubuntu/22.04-ppa/Dockerfile
+++ b/variants/ubuntu/22.04-ppa/Dockerfile
@@ -9,4 +9,4 @@ RUN apt-get update \
     && apt-get remove -y --autoremove software-properties-common \
     && rm -rf /var/lib/apt/lists/*
 
-CMD ["ansible"]
+CMD ["/bin/bash"]

--- a/variants/ubuntu/22.04/Dockerfile
+++ b/variants/ubuntu/22.04/Dockerfile
@@ -6,4 +6,4 @@ RUN apt-get update \
     && apt-get install -y ansible=2.10.7+merged+base+2.10.8+dfsg-1 openssh-client \
     && rm -rf /var/lib/apt/lists/*
 
-CMD ["ansible"]
+CMD ["/bin/bash"]


### PR DESCRIPTION
Setting `CMD` values to `ansible` is mostly pointless as `ansible` is an executable rather than a shell. Parameters specified after the `docker run image:tag` command are ignored unless `ansible` is set as the images' `ENTRYPOINT`. Yet since `ansible-playbook` is most likely to be used in images, specifying `ansible` as the images' `ENTRYPOINT` would introduce a breaking-change in design of the images potentially reducing their usefulness by being too specific in design. Having a more generic design is preferred and allows administrators to also interact within container shell environments for administrating systems in combination with `ansible` binaries.

This reverts commit 862bf05c4e4efd102806e9fb60897b98715fa1ae.