### PR TITLE
Docs (readme): Use new GitHub workflow badge routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![badge-build-github-workflows-img][]][badge-build-github-workflows-src] [![badge-image-dockerhub-version-badge][]][badge-image-dockerhub-tags-src] [![badge-image-dockerhub-size-badge][]][badge-image-dockerhub-tags-src]
 
-[badge-build-github-workflows-img]: https://github.com/joeltimothyoh/docker-ansible/workflows/build/badge.svg
-[badge-build-github-workflows-src]: https://github.com/joeltimothyoh/docker-ansible/actions
+[badge-build-github-workflows-img]: https://github.com/joeltimothyoh/docker-ansible/actions/workflows/build.yml/badge.svg
+[badge-build-github-workflows-src]: https://github.com/joeltimothyoh/docker-ansible/actions/workflows/build.yml
 [badge-image-dockerhub-src]: https://hub.docker.com/r/joeltimothyoh/ansible
 [badge-image-dockerhub-tags-src]: https://hub.docker.com/r/joeltimothyoh/ansible/tags
 [badge-image-dockerhub-version-badge]: https://img.shields.io/docker/v/joeltimothyoh/ansible/latest?label=v<tag>&style=flat-square


### PR DESCRIPTION
See https://github.com/badges/shields/issues/8671

Also uses the new default status badge urls